### PR TITLE
add support of private repos in dependencies

### DIFF
--- a/embedded-files/.DINAR/image/build.d/099-create-netrc
+++ b/embedded-files/.DINAR/image/build.d/099-create-netrc
@@ -1,0 +1,3 @@
+#!/bin/bash
+mv /opt/odoo/custom/.netrc ~/
+chmod 600 ~/.netrc

--- a/embedded-files/.DINAR/image/build.d/101-rm-netrc
+++ b/embedded-files/.DINAR/image/build.d/101-rm-netrc
@@ -1,0 +1,2 @@
+#!/bin/bash
+rm ~/.netrc

--- a/static-files/all/.github/workflows/DINAR.yml
+++ b/static-files/all/.github/workflows/DINAR.yml
@@ -60,6 +60,11 @@ jobs:
         run: |
           bash DINAR/workflow-files/configure-docker.sh ${{ secrets.DINAR_TOKEN }}
 
+          cat <<- EOF > REPO/.DINAR/image/.netrc
+          machine github.com
+          login $GITHUB_ACTOR
+          password ${{ secrets.DINAR_TOKEN }}
+          EOF
       - name: dinar-odoo-base
         uses: elgohr/Publish-Docker-Github-Action@master
         env:


### PR DESCRIPTION
it works with github.com. Other services can be configured in the similar way in
DINAR fork